### PR TITLE
Fix IndexOutOfBoundsException when adding new task

### DIFF
--- a/app/src/main/java/marabillas/loremar/taskador/background/MainInAppManager.java
+++ b/app/src/main/java/marabillas/loremar/taskador/background/MainInAppManager.java
@@ -264,10 +264,10 @@ public class MainInAppManager extends BackgroundTaskManager implements
                     // list. Notify the recycler view's adapter that is bound to this list to
                     // update its view.
                     int id = data.getInt("id");
-                    todoTasks.add(new IdTaskPair(id, task));
+                    IdTaskPair entry = new IdTaskPair(id, task);
 
                     mainInApp.dismissProgressDialog();
-                    mainInApp.getToDoTasksFragment().notifyTaskAdded(todoTasks.size() - 1);
+                    mainInApp.getToDoTasksFragment().addTask(entry);
                 } catch (FailedToGetFieldException e) {
                     logError(e.getMessage());
                     mainInApp.dismissProgressDialog();

--- a/app/src/main/java/marabillas/loremar/taskador/ui/adapter/TodoTasksRecyclerViewAdapter.java
+++ b/app/src/main/java/marabillas/loremar/taskador/ui/adapter/TodoTasksRecyclerViewAdapter.java
@@ -81,6 +81,11 @@ public class TodoTasksRecyclerViewAdapter extends RecyclerView.Adapter<TodoTasks
         notifyDataSetChanged();
     }
 
+    public void addItem(IdTaskPair item) {
+        tasks.add(item);
+        notifyItemInserted(tasks.indexOf(item));
+    }
+
     public void removeItem(int position) {
         tasks.remove(position);
         notifyItemRemoved(position);

--- a/app/src/main/java/marabillas/loremar/taskador/ui/fragment/ToDoTasksFragment.java
+++ b/app/src/main/java/marabillas/loremar/taskador/ui/fragment/ToDoTasksFragment.java
@@ -100,18 +100,13 @@ public class ToDoTasksFragment extends Fragment {
         }
     }
 
-    /**
-     * Notify the recycler view's adapter to update its view for the newly added task in the list.
-     *
-     * @param position position of the new task in the list
-     */
-    public void notifyTaskAdded(final int position) {
+    public void addTask(final IdTaskPair entry) {
         MainInAppActivity mainInAppActivity = (MainInAppActivity) getActivity();
         if (mainInAppActivity != null) {
             mainInAppActivity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    adapter.notifyItemInserted(position);
+                    adapter.addItem(entry);
                 }
             });
         }


### PR DESCRIPTION
This is most likely caused by changing the list on another thread while
notifying item insertion on the main thread.